### PR TITLE
Updated gulp to version 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/jonicious/jonas.re/issues"
   },
   "dependencies": {
-    "gulp": "3.8.10",
+    "gulp": "3.9.0",
     "browser-sync": "~1.8.3",
     "gulp-htmlmin": "~0.2.0",
     "gulp-concat": "~2.4.3",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>