### PR TITLE
Updated gulp-autoprefixer to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp-concat": "~2.4.3",
     "gulp-uglify": "~1.0.2",
     "gulp-sass": "~1.2.4",
-    "gulp-autoprefixer": "~2.0.0",
+    "gulp-autoprefixer": "3.0.2",
     "gulp-cssmin": "~0.1.6",
     "gulp-notify": "2.1.0",
     "gulp-rename": "~1.2.0",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>