### PR TITLE
Updated gulp-htmlmin to version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "gulp": "3.8.10",
     "browser-sync": "~1.8.3",
-    "gulp-htmlmin": "~0.2.0",
+    "gulp-htmlmin": "1.2.0",
     "gulp-concat": "~2.4.3",
     "gulp-uglify": "~1.0.2",
     "gulp-sass": "~1.2.4",


### PR DESCRIPTION
:rocket:

gulp-htmlmin just published version 1.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>