### PR TITLE
FIX: Linkedin link height issue

### DIFF
--- a/src/components/ConnectButton.js
+++ b/src/components/ConnectButton.js
@@ -13,6 +13,7 @@ export const ConnectButton = styled.a.attrs({
     border: 2px solid ${WHITE};
     color: ${BLACK};
     transition: 80ms ease-in;
+    display: inline-block;
 
     &:hover {
         background: ${BLACK};


### PR DESCRIPTION
Link has wrong height because it's default is display: inline.

Fixes https://github.com/jonicious/jonas.re/issues/82